### PR TITLE
Fixed bug in filenames.csv for reading psi

### DIFF
--- a/input/filenames.csv
+++ b/input/filenames.csv
@@ -42,7 +42,7 @@ ea,ea
 RH,
 tts,tts
 tto,tto
-psi ,psi
+psi,psi
 ,
 Cab,Cab
 Cca,Cca


### PR DESCRIPTION
In the default "filenames.csv", the variable "psi" is actually
seen as "psi ". This means that in SCOPE.m, if psi is defined in
filenames.csv and should be read in from a file, it will not locate
it. The "psi" in SCOPE.m (see cols variable) cannot match to the
"psi " variable in filenames.csv. I have removed the space and it
is now working as expected.