### PR TITLE
Missing variable in filenames.csv

### DIFF
--- a/input/filenames.csv
+++ b/input/filenames.csv
@@ -33,6 +33,7 @@ tts_file,
 ,
 "Variables below are COLUMN NAMES in time_series_files (meteo_ec_csv, vegetation_retrieved_csv)",
 t,t
+year,
 Rin,Rin
 Rli,
 p,


### PR DESCRIPTION
The variable "year" is missing in the default filenames.csv file.
This results in a default year of 2020 being applied to any
simulation that uses the COLUMN NAMES in a time series option run.
I have added the variable "year" which lines up with the variable
in the cols list in SCOPE.m, so it can be read in appropriately.